### PR TITLE
Add Las Tortillas de Sauces 3 branding to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Marxia — Orden Rápida</title>
+  <meta name="description" content="Ordena fácilmente en Las Tortillas de Sauces 3 (LasTortillasdeSauces3) con nuestra experiencia digital segura y rápida.">
+  <title>Las Tortillas de Sauces 3 — Orden Rápida LasTortillasdeSauces3</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -11,7 +12,10 @@
   <div id="error-container" style="display: none;"></div>
   <div class="wrap">
     <header>
-      <h1>Orden Rápida</h1>
+      <div class="brand" aria-label="Las Tortillas de Sauces 3, también conocida como LasTortillasdeSauces3">
+        <h1>Las Tortillas de Sauces 3</h1>
+        <p class="tagline">Orden Rápida oficial de <span class="nowrap">LasTortillasdeSauces3</span></p>
+      </div>
       <div class="controls">
         <button id="lang" class="toggle" aria-label="EN/ES">ES</button>
         <button id="theme" class="toggle" aria-label="Light/Dark">🌙</button>

--- a/style.css
+++ b/style.css
@@ -7,7 +7,11 @@
 html,body{margin:0;padding:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:linear-gradient(180deg,#0e1324,#0b1720,#151a2e);color:var(--fg);min-height:100%}
 body{display:flex;align-items:center;justify-content:center}
 .wrap{width:100%;max-width:1200px;margin:auto;padding:2rem 1rem}
-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:2rem}
+header{display:flex;justify-content:space-between;align-items:center;margin-bottom:2rem;gap:1.5rem}
+.brand{display:flex;flex-direction:column;gap:.35rem;max-width:100%}
+.brand h1{margin:0;font-size:1.9rem;line-height:1.2}
+.tagline{margin:0;font-size:1rem;color:var(--muted);font-weight:600}
+.nowrap{white-space:nowrap}
 h1{margin:0;font-size:1.8rem}
 .controls{display:flex;gap:.5rem}
 .toggle{padding:.5rem 1rem;border:1px solid var(--line);background:var(--card);color:var(--fg);border-radius:999px;font-weight:700;cursor:pointer}


### PR DESCRIPTION
## Summary
- update the page metadata and header branding to highlight Las Tortillas de Sauces 3 / LasTortillasdeSauces3
- add a descriptive tagline in the header so both brand names are visible to visitors
- introduce supporting styles for the updated brand block while keeping the existing layout intact

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c87c36078c832b882464094bcdee4f