### PR TITLE
Document frame-ancestors requirements and harden worker responses

### DIFF
--- a/docs/csp-frame-ancestors.md
+++ b/docs/csp-frame-ancestors.md
@@ -1,0 +1,33 @@
+# Why the browser warns about `frame-ancestors` in a meta Content-Security-Policy
+
+Modern browsers intentionally ignore the `frame-ancestors` directive when it
+is delivered via an HTML `<meta http-equiv="Content-Security-Policy">` tag.
+`frame-ancestors` is only honored when it is shipped in the HTTP
+`Content-Security-Policy` response header, because the directive controls
+whether the entire document can be embedded in an iframe. When the policy is
+set via markup an attacker that successfully injects HTML into the page could
+just remove or alter the tag, so browsers deprecate and ignore the meta form of
+`frame-ancestors` ([Chromium tracking issue](https://chromestatus.com/feature/5579556305502208)).
+
+If you see the console warning:
+
+```
+The Content Security Policy directive 'frame-ancestors' is ignored when delivered via a <meta> element.
+```
+
+it means the page tried to advertise `frame-ancestors` inside HTML. To enforce
+framing restrictions you must serve the directive from the origin server. A few
+options:
+
+* **Cloudflare Pages / Workers:** add
+  `Content-Security-Policy: frame-ancestors 'none';` (or the appropriate allow
+  list) in the worker script or Pages Functions response headers.
+* **Netlify:** place an `_headers` file in the published folder containing a
+  rule such as `/*\n  Content-Security-Policy: frame-ancestors 'none'`.
+* **Any other static host or CDN:** configure the platform’s HTTP response
+  headers so every HTML page includes the CSP header with the `frame-ancestors`
+  directive.
+
+The front-end now includes a JavaScript frame-busting fallback so the page
+refuses to render when embedded, but you should still configure the HTTP header
+policy for defense in depth and to satisfy modern browser requirements.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://solitary-leaf-f8a9.mussle-creashure.workers.dev; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' https://fonts.googleapis.com">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://solitary-leaf-f8a9.mussle-creashure.workers.dev; font-src 'self' https://fonts.gstatic.com; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' https://fonts.googleapis.com">
+  <!-- frame-ancestors directives must be served via HTTP response headers per CSP3 -->
   <meta name="description" content="Ordena fácilmente en Las Tortillas de Sauces 3 (LasTortillasdeSauces3) con nuestra experiencia digital segura y rápida.">
   <meta name="robots" content="index,follow">
   <meta name="referrer" content="strict-origin-when-cross-origin">
@@ -61,6 +62,6 @@
   <div id="loader" class="loader-overlay"><div class="loader"></div></div>
   <div id="toast" class="toast">¡Pedido enviado con éxito!</div>
 
-  <script type="module" src="script.js"></script>
+  <script type="module" src="script.js?v=20250916"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- document why browsers warn about frame-ancestors in meta CSP tags and how to configure the directive on the hosting platform, plus annotate the HTML head with the header requirement and bust cached scripts
- add a JavaScript frame-busting fallback so the app refuses to render in hostile frames while the real CSP header is configured server-side
- only parse worker replies as JSON when their content type indicates JSON so HTML error pages no longer trigger console SyntaxErrors and unauthorized/server responses get clearer toasts

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8dfef3488832b9872cee9ce2f829f