### PR TITLE
Adjust brand styling for light theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -175,3 +175,5 @@ aside.card{display:flex;flex-direction:column}
 
 [data-theme="light"] body{background:linear-gradient(135deg,#f3fbf7,#eaf2ff,#ffe9ef)}
 [data-theme="light"] .btn-adding{background:#22c3a6 !important;color:#0b0f18 !important}
+[data-theme="light"] .brand h1{color:#000;font-weight:900}
+[data-theme="light"] .brand .tagline{color:#000;font-weight:700}


### PR DESCRIPTION
## Summary
- add light-theme overrides so the brand title and tagline render in bold black text when the light mode toggle is used

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8ea621c5c832b94b0fc93492e039b